### PR TITLE
V2 stable

### DIFF
--- a/db/fields/FileField.php
+++ b/db/fields/FileField.php
@@ -28,7 +28,7 @@ class FileField extends WaxModelField {
 			unset($options['allowed_extensions']);
 		}
 		$this->col_name = $column;
-		parent::__construct($column, $model, $options = array());
+		parent::__construct($column, $model, $options);
   }
 
   public function setup() {	


### PR DESCRIPTION
Updated Filefield.php so that the $options array is passed through to the parent constructor rather than sending an empty array.

Main issue there was that the file_root and url_root weren't being set. 
