### PR TITLE
allow non numeric/sequential recordset keys

### DIFF
--- a/db/WaxModelAssociation.php
+++ b/db/WaxModelAssociation.php
@@ -38,16 +38,16 @@ class WaxModelAssociation extends WaxRecordset {
   }
   
   public function valid() {
-    if(is_numeric($this->rowset[$this->key])){ //lazy loading
+    if(is_numeric($this->rowset[$this->key()])){ //lazy loading
       $model = get_class($this->target_model);
       while($this->key < count($this->rowset)){
-        $this->current_object = new $model($this->rowset[$this->key]);
+        $this->current_object = new $model($this->rowset[$this->key()]);
         if($this->current_object->primval()) return true;
         $this->next();
       }
       return false;
     }else{ //normal loading
-      if($this->rowset[$this->key]) return true;
+      if($this->rowset[$this->key()]) return true;
       return false;
     }
   }

--- a/db/WaxRecordset.php
+++ b/db/WaxRecordset.php
@@ -12,11 +12,13 @@ class WaxRecordset implements Iterator, ArrayAccess, Countable {
   protected $model = false;
   protected $obj = false;
   protected $key = 0;
+  private $key_map;
   protected $constraints = array();
   public $rowset;
   
   public function __construct(WaxModel $model, $rowset) {
     $this->rowset = $rowset;
+    $this->key_map = array_keys($rowset);
     $this->model = $model;
   }
   
@@ -25,11 +27,11 @@ class WaxRecordset implements Iterator, ArrayAccess, Countable {
   }
   
   public function current() {
-    return $this->offsetGet($this->key);
+    return $this->offsetGet($this->key());
   }
   
   public function key() {
-    return $this->key;
+    return $this->key_map[$this->key];
   }
   
   public function rewind() {
@@ -37,7 +39,7 @@ class WaxRecordset implements Iterator, ArrayAccess, Countable {
   }
   
   public function valid() {
-    if($this->rowset[$this->key]) return true;
+    if($this->rowset[$this->key()]) return true;
     return false;
   }
   


### PR DESCRIPTION
Before this, if you created a recordset with a rowset array that was non numeric (or even just non sequential, which is how we found the bug) it would break, not returning the correct results from the rowset. I've done this pull request cause it's a pretty low level change, wanted everyone to check it before we put it live.
